### PR TITLE
riotboot_usb_dfu: Implementing state `Runtime_mode` after dfu-util download

### DIFF
--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -1,6 +1,7 @@
 # If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
 # USB serials to only select the UART bridge of the embedded EDBG CMSIS-DAP
 # debugger.
+PROGRAMMERS_SUPPORTED=dfu-util
 TTY_BOARD_FILTER := --model 'EDBG CMSIS-DAP'
 
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/sys/usb/usbus/dfu/dfu.c
+++ b/sys/usb/usbus/dfu/dfu.c
@@ -46,13 +46,11 @@ static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
                               usbdev_ep_t *ep, usbus_event_transfer_t event);
 static void _init(usbus_t *usbus, usbus_handler_t *handler);
 
+#define DEFAULT_XFER_SIZE 64
+
 #ifdef MODULE_RIOTBOOT_USB_DFU
-static void _reboot(void *arg);
-static ztimer_t scheduled_reboot = { .callback=_reboot };
 #define REBOOT_DELAY 2
 #endif
-
-#define DEFAULT_XFER_SIZE 64
 
 static size_t _gen_dfu_descriptor(usbus_t *usbus, void *arg)
 {
@@ -87,14 +85,6 @@ static const usbus_descr_gen_funcs_t _dfu_descriptor = {
     },
     .len_type = USBUS_DESCR_LEN_FIXED,
 };
-
-#ifdef MODULE_RIOTBOOT_USB_DFU
-static void _reboot(void *arg)
-{
-    (void)arg;
-    pm_reboot();
-}
-#endif
 
 void usbus_dfu_init(usbus_t *usbus, usbus_dfu_device_t *handler, unsigned mode)
 {
@@ -221,12 +211,19 @@ static int _dfu_class_control_req(usbus_t *usbus, usbus_dfu_device_t *dfu, usb_s
                 DEBUG("GET STATUS GO TO IDLE\n");
             }
             else if (dfu->dfu_state == USB_DFU_STATE_DFU_MANIFEST_SYNC) {
-                /* Scheduled reboot, so we can answer back dfu-util before rebooting */
-                dfu->dfu_state = USB_DFU_STATE_DFU_DL_IDLE;
-#ifdef MODULE_RIOTBOOT_USB_DFU
-                ztimer_set(ZTIMER_SEC, &scheduled_reboot, 1);
-#endif
+                /* Set the dfu_state to manifest phase completed, but send a last answer 
+                back dfu-util before rebooting */
+                dfu->dfu_state = USB_DFU_STATE_DFU_MANIFEST;
             }
+#ifdef MODULE_RIOTBOOT_USB_DFU
+            else if (dfu->dfu_state == USB_DFU_STATE_DFU_MANIFEST){
+                /*The device needs to point to FLASSH_ADDR when download process is completed
+                This will load the base firmware (jump to application) */
+                reset_addr = FLASH_ADDR;
+                pm_reboot();
+            }
+#endif
+
             memset(&buf, 0, sizeof(buf));
             buf.status = 0;
             buf.timeout = USB_DFU_DETACH_TIMEOUT_MS;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
These changes was applied only on the samr21-xpro board.
- affects the usb/usbus only toke reference about the riotboot_dfu usb features. and dfu manifest phases.
- Was deleted the schedule resetting to the test. 
- Ztimer callback wait was deleted.
- adds points to `FLASH_ADDR` where is located the base firmware.
 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
with these new changes you need to flash the bootloader/riotboot_dfu in your board.

- connect the usb to `EDBG_USB` port
```
make -C bootloader/riotboot_dfu 
```
when the bootloader is flashed in the board.  proceed to disconnet the usb from the `EDBG_USB` port and then connect it to `TARGET_USB` port on the board.
Will need to download the application firmware via riotboot_dfu (bootloader) / dfu-util
```
FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/blinky/ BOARD=samr21-xpro PROGRAMMER=dfu-util all riotboot/flash-slot0
```
on your board should run the application after download.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
You could see more information in https://www.st.com/resource/en/application_note/cd00264379-usb-dfu-protocol-used-in-the-stm32-bootloader-stmicroelectronics.pdf.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
